### PR TITLE
Fixed TypeError in fallback

### DIFF
--- a/src/drill-sergeant.js
+++ b/src/drill-sergeant.js
@@ -25,7 +25,7 @@ var schedule = require('node-schedule');
 module.exports = function(robot) {
 	var token = process.env.HUBOT_DRILL_SERGEANT_GITHUB_TOKEN;
 	var staleTime = process.env.HUBOT_DRILL_SERGEANT_STALE_TIME || 24;
-	var repos = (process.env.HUBOT_DRILL_SERGEANT_REPOS || []).split(',');
+	var repos = (process.env.HUBOT_DRILL_SERGEANT_REPOS || '').split(',');
 	var crontab = process.env.HUBOT_DRILL_SERGEANT_SCHEDULE || '10 * * * *';
 	var announcementRoom = process.env.HUBOT_DRILL_SERGEANT_ROOM;
 	var client;


### PR DESCRIPTION
If `process.env.HUBOT_DRILL_SERGEANT_REPOS` is not defined, the code was falling back to an array instead of an empty string, causing `TypeError: Object  has no method split`
